### PR TITLE
-vcpkg is a submodule: useful to have versioning control of the depen…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,13 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgGitCommitId: '6282cab61d175974b1af06473db584b9b80dcd48'
-            vcpkgPackages: 'grpc'
           - os: ubuntu-latest
             triplet: x64-linux
-            vcpkgGitCommitId: '6282cab61d175974b1af06473db584b9b80dcd48'
-            vcpkgPackages: 'grpc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
+        with:
+          submodules: true
       - name: Install Qt
         uses: ouuan/install-qt-action@v2.3.1
         with:
@@ -36,40 +34,43 @@ jobs:
       - name: Cache vcpkg artifacts
         uses: actions/cache@v1
         env:
-          cache-name: cache-vcpkg-modules
+          vcpkgResponseFile: '${{ github.workspace }}/vcpkg_${{ matrix.triplet }}.txt'
         with:
           path: ${{ github.workspace }}/vcpkg/
-          key: ${{ env.cache-name }}-${{ runner.os }}
+          # Ensure the cache is invalidated any time vcpkg version changes, or a different set of packages is being used.
+          key: ${{ hashFiles( env.vcpkgResponseFile ) }}-${{ hashFiles('.git/modules/vcpkg/HEAD') }}-${{ runner.os }}
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@v0.10
+        uses: lukka/run-vcpkg@v0
         id: runvcpkg
+        env:
+          vcpkgResponseFile: '${{ github.workspace }}/vcpkg_${{ matrix.triplet }}.txt'
         with:
-          vcpkgArguments: '${{ matrix.vcpkgPackages }}'
-          vcpkgTriplet: '${{ matrix.triplet }}'
-          vcpkgGitCommitId: '${{ matrix.vcpkgGitCommitId }}'
+          vcpkgArguments: '@${{ env.vcpkgResponseFile }}'
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
       - name: Prints outputs of run-vcpkg task
         run: echo "'${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}' '${{  steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}' "
-      - name: Build ResInsight-x64 Windows
-        if: "contains( matrix.os, 'windows')"
+      - name: Build ResInsight-x64
+        uses: lukka/run-cmake@v0
+        with:
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeAppendedArgs: -G Ninja -DCMAKE_BUILD_TYPE=Release -DRESINSIGHT_ENABLE_GRPC=true -DRESINSIGHT_GRPC_PYTHON_EXECUTABLE=python -DRESINSIGHT_ENABLE_PRECOMPILED_HEADERS=true -DRESINSIGHT_ENABLE_UNITY_BUILD=true
+          buildDirectory: ${{ github.workspace }}/cmakebuild
+          buildWithCMakeArgs: '--target package'
+          useVcpkgToolchainFile: true
+      - name: Remove packages/_CPack_Packages
+        shell: bash
         run: |
-          mkdir cmakebuild
-          cd cmakebuild
-          cmake .. -DRESINSIGHT_ENABLE_GRPC=true -DRESINSIGHT_GRPC_PYTHON_EXECUTABLE=python -DRESINSIGHT_ENABLE_PRECOMPILED_HEADERS=true -DRESINSIGHT_ENABLE_UNITY_BUILD=true -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -A x64
-          cmake --build . --config Release --target PACKAGE
-          rd packages/_CPack_Packages -Recurse
-      - name: Build ResInsight-x64 Linux
-        if: "contains( matrix.os, 'ubuntu')"
-        run: |
-          mkdir cmakebuild
-          cd cmakebuild
-          cmake .. -DRESINSIGHT_ENABLE_GRPC=true -DRESINSIGHT_GRPC_PYTHON_EXECUTABLE=python -DRESINSIGHT_ENABLE_PRECOMPILED_HEADERS=true -DRESINSIGHT_ENABLE_UNITY_BUILD=true -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-          cmake --build . --config Release 
-          make package
           rm -rf packages/_CPack_Packages
+      - name: dir
+        run: find ${{ runner.workspace }}
+        if: "!contains( matrix.os, 'windows')"
+      - name: dir
+        run: gci -recurse ${{ runner.workspace }}
+        if: contains( matrix.os, 'windows')      
       - name: Test with pytest
         if: "contains( matrix.os, 'windows')" # To be used when RESINSIGHT_GRPC_PYTHON_EXECUTABLE can be 'python' without extention in PATH
         env:
-          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ApplicationCode/Release/ResInsight.exe
+          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ApplicationCode/ResInsight.exe
         run: |
           cd ApplicationCode/GrpcInterface/Python/rips
           pytest --console
@@ -77,4 +78,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ResInsight
-          path: ${{ runner.workspace }}/ResInsight/cmakebuild/packages
+          path: ${{ github.workspace }}/cmakebuild/packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/ApplicationCode/CMakeLists.txt
+++ b/ApplicationCode/CMakeLists.txt
@@ -597,12 +597,12 @@ foreach (FILE_TO_COPY ${RI_DLL_FILENAMES})
     add_custom_command(TARGET ResInsight POST_BUILD
                         COMMAND ${CMAKE_COMMAND} -E copy_if_different  
                         "${FILE_TO_COPY}"  
-                        "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>")
+                        "${CMAKE_CURRENT_BINARY_DIR}")
     if (_unityTargetName)
         add_custom_command(TARGET ${_unityTargetName} POST_BUILD
                             COMMAND ${CMAKE_COMMAND} -E copy_if_different  
                             "${FILE_TO_COPY}"  
-                            "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>")
+                            "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
 endforeach()
 
@@ -733,7 +733,7 @@ if (RESINSIGHT_PRIVATE_INSTALL)
         if (RESINSIGHT_ENABLE_GRPC)
             set (GRPC_DLL_NAMES libprotobuf cares zlib1)
             foreach (dllname ${GRPC_DLL_NAMES})		  
-              list(APPEND RESINSIGHT_FILES "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/${dllname}.dll")
+              list(APPEND RESINSIGHT_FILES "${CMAKE_CURRENT_BINARY_DIR}/${dllname}.dll")
             endforeach(dllname ${GRPC_DLL_NAMES})
 	    endif()
 

--- a/ApplicationCode/GeoMech/OdbReader/OdbSetup.cmake
+++ b/ApplicationCode/GeoMech/OdbReader/OdbSetup.cmake
@@ -20,8 +20,8 @@ if (MSVC)
 	foreach (aDLL ${RI_ODB_DLLS})
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
                            COMMAND ${CMAKE_COMMAND} -E copy_if_different  
-						   "${RESINSIGHT_ODB_API_DIR}/lib/${aDLL}"  
-						   "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>")
+						   "${RESINSIGHT_ODB_API_DIR}/lib/${aDLL}"
+						   "${CMAKE_CURRENT_BINARY_DIR}")
     endforeach()
 
 endif(MSVC)

--- a/OctavePlugin/CMakeLists.txt
+++ b/OctavePlugin/CMakeLists.txt
@@ -231,19 +231,11 @@ add_custom_target(octave_plugins ALL DEPENDS
 
             get_filename_component(Filename "${oct_bin}" NAME)
 
-            if(MSVC)
-                add_custom_command(TARGET octave_plugins POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    "${oct_bin}"
-                    "${CMAKE_CURRENT_BINARY_DIR}/../ApplicationCode/$<CONFIGURATION>/${Filename}"
-                )
-            else()
-                add_custom_command(TARGET octave_plugins POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    "${oct_bin}"
-                    "${CMAKE_CURRENT_BINARY_DIR}/../ApplicationCode/${Filename}"
-                )
-            endif()
+            add_custom_command(TARGET octave_plugins POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${oct_bin}"
+                "${CMAKE_CURRENT_BINARY_DIR}/../ApplicationCode/${Filename}"
+            )
         endforeach( oct_bin )
     endif()
 

--- a/appveyor-build.ps1
+++ b/appveyor-build.ps1
@@ -29,12 +29,12 @@ $env:PATH = "$env:QT5\bin;$env:PATH"
 mkdir cmakebuild
 cd .\cmakebuild
 
-cmake -DCMAKE_BUILD_TYPE=Release -DRESINSIGHT_ENABLE_UNITY_BUILD=on -DRESINSIGHT_ENABLE_PRECOMPILED_HEADERS=on "-DCMAKE_PREFIX_PATH=$env:QT5" -DRESINSIGHT_ENABLE_GRPC=true -DRESINSIGHT_GRPC_PYTHON_EXECUTABLE=C:/Python37/python.exe -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -A x64 ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DRESINSIGHT_ENABLE_UNITY_BUILD=on -DRESINSIGHT_ENABLE_PRECOMPILED_HEADERS=on "-DCMAKE_PREFIX_PATH=$env:QT5" -DRESINSIGHT_ENABLE_GRPC=true -DRESINSIGHT_GRPC_PYTHON_EXECUTABLE=C:/Python37/python.exe -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -A x64 ..
 
 cmake --build . --target ResInsight --config Release
 
 ### TEST
-$env:RESINSIGHT_EXECUTABLE="$env:APPVEYOR_BUILD_FOLDER/cmakebuild/ApplicationCode/Release/ResInsight.exe" 
+$env:RESINSIGHT_EXECUTABLE="$env:APPVEYOR_BUILD_FOLDER/cmakebuild/ApplicationCode/ResInsight.exe" 
 
 cd ../ApplicationCode/GrpcInterface/Python/rips
 python -m pytest --console

--- a/vcpkg_x64-linux.txt
+++ b/vcpkg_x64-linux.txt
@@ -1,0 +1,3 @@
+grpc
+--triplet
+x64-linux

--- a/vcpkg_x64-windows.txt
+++ b/vcpkg_x64-windows.txt
@@ -1,0 +1,3 @@
+grpc
+--triplet
+x64-windows


### PR DESCRIPTION
…dencies;

-use run-cmake action for building both linux and windows;
-use ninja to improve build time;
-use vcpkg response file installing dependencies; same is to be used on CI and locally by devs;
-omit <CONFIGURATION> from any path. A build directory should contain one flavor only (i.e. Debug or Release)